### PR TITLE
Fixes #146: After enabling the card counter app in admin side, "card counter" app did not displayed in Footer apps list issue fixed

### DIFF
--- a/r_card_counter/app.json
+++ b/r_card_counter/app.json
@@ -7,7 +7,7 @@
     "author_email": "info@restya.com",
     "author_url": "",
     "version": "0.1.1",
-    "price": "Paid",
+    "price": "Free",
     "icon": "apps/r_card_counter/img/r-card-counter.png",
     "settings_description": "",
     "large_description": [


### PR DESCRIPTION
After enabling the card counter app in admin side, "card counter" app did not displayed in Footer apps list issue fixed